### PR TITLE
Store public API keys based on domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) as of version 5.0.0.
 
+## [Unreleased]
+* Run migrations across a multisite network via a background task ([#48]).
+
 ## [5.0.1]
 * Ensure that legacy API keys are exchanged before making any other API requests ([#45]).
 
@@ -117,6 +120,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 1.0
 * First version!
 
+[Unreleased]: https://github.com/101videos/wp101plugin/compare/master...develop
 [5.0.0]: https://github.com/leftlane/wp101plugin/releases/tag/v5.0.0
 [5.0.1]: https://github.com/leftlane/wp101plugin/releases/tag/v5.0.1
 [#45]: https://github.com/leftlane/wp101plugin/issues/45
+[#48]: https://github.com/101videos/wp101plugin/pull/48

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -239,7 +239,7 @@ function render_settings_page() {
  * Flush the public key after saving the private key.
  */
 function clear_public_api_key() {
-	delete_transient( API::PUBLIC_API_KEY_OPTION );
+	delete_transient( API::get_instance()->get_public_api_key_name() );
 
 	// Prime the cache with the new public + private keys.
 	$api = TemplateTags\api();

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -49,13 +49,6 @@ class API {
 	const API_KEY_OPTION = 'wp101_api_key';
 
 	/**
-	 * Transient key for the site's public API key.
-	 *
-	 * @var string
-	 */
-	const PUBLIC_API_KEY_OPTION = 'wp101-public-api-key';
-
-	/**
 	 * The User-Agent string that will be passed with API requests.
 	 *
 	 * @var string
@@ -158,7 +151,8 @@ class API {
 	 * @return string|WP_Error The public API key or any WP_Error that occurred.
 	 */
 	public function get_public_api_key() {
-		$public_key = get_transient( self::PUBLIC_API_KEY_OPTION );
+		$key_name   = $this->get_public_api_key_name();
+		$public_key = get_transient( $key_name );
 
 		if ( $public_key ) {
 			return $public_key;
@@ -175,9 +169,21 @@ class API {
 
 		$public_key = $response['publicKey'];
 
-		set_transient( self::PUBLIC_API_KEY_OPTION, $public_key, 0 );
+		set_transient( $key_name, $public_key, 0 );
 
 		return $public_key;
+	}
+
+	/**
+	 * Get the public API key name.
+	 *
+	 * The name consists of a static prefix followed by the first 8 characters of an md5 hash of
+	 * the site URL.
+	 *
+	 * @return string
+	 */
+	public function get_public_api_key_name() {
+		return 'wp101-public-api-key-' . substr( md5( site_url( '/' ) ), 0, 8 );
 	}
 
 	/**

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -165,7 +165,7 @@ class ApiTest extends TestCase {
 		$name = $api->get_public_api_key_name();
 		$key  = uniqid();
 
-		set_transient( $name, $key, 0 );
+		set_transient( $name, $key, DAY_IN_SECONDS );
 
 		$this->assertEquals( $key, API::get_instance()->get_public_api_key() );
 	}

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -84,7 +84,7 @@ class SettingsTest extends TestCase {
 		$name = $api->get_public_api_key_name();
 
 		update_option( 'wp101_api_key', md5( uniqid() ) );
-		set_transient( $name, uniqid(), 0 );
+		set_transient( $name, uniqid(), DAY_IN_SECONDS );
 
 		// Change the private key.
 		update_option( 'wp101_api_key', md5( uniqid() ) );

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -78,16 +78,17 @@ class SettingsTest extends TestCase {
 	}
 
 	public function test_public_key_is_cleared_when_private_key_changes() {
-		update_option( 'wp101_api_key', md5( uniqid() ) );
-		set_transient( API::PUBLIC_API_KEY_OPTION, uniqid(), 0 );
-
-		$api = $this->mock_api();
+		$api  = $this->mock_api();
 		$api->shouldReceive( 'clear_api_key' )->once();
 		$api->shouldReceive( 'get_public_api_key' )->once();
+		$name = $api->get_public_api_key_name();
+
+		update_option( 'wp101_api_key', md5( uniqid() ) );
+		set_transient( $name, uniqid(), 0 );
 
 		// Change the private key.
 		update_option( 'wp101_api_key', md5( uniqid() ) );
 
-		$this->assertFalse( get_transient( API::PUBLIC_API_KEY_OPTION ) );
+		$this->assertFalse( get_transient( $name ) );
 	}
 }

--- a/tests/test-uninstall.php
+++ b/tests/test-uninstall.php
@@ -47,7 +47,7 @@ class UninstallTest extends TestCase {
 
 	public function test_clear_caches() {
 		$transients = array(
-			API::PUBLIC_API_KEY_OPTION,
+			API::get_instance()->get_public_api_key_name(),
 			'wp101_topics',
 			'wp101_jetpack_topics',
 			'wp101_woocommerce_topics',

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -24,7 +24,7 @@ class TestCase extends WP_UnitTestCase {
 		parent::tearDown();
 
 		delete_option( 'wp101_api_key' );
-		delete_transient( API::PUBLIC_API_KEY_OPTION );
+		delete_transient( API::get_instance()->get_public_api_key_name() );
 
 		$instance = new ReflectionProperty( API::get_instance(), 'instance' );
 		$instance->setAccessible( true );


### PR DESCRIPTION
Since the WP101 Plugin SaaS generates a unique public API key for each domain/private API key combination, the public API key should be stored in a transient that's keyed to the current domain. This will ensure that if the value of `site_url()` ever changes, the appropriate public API key will be retrieved from the SaaS, fixing #49.

Additionally, public API keys are now only cached for 24 hours, enabling older keys to roll off after (for instance) a domain change.