### PR TITLE
Add the wp101_excluded_topics filter

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -230,14 +230,36 @@ class API {
 	 * @return array An array of all available series and topics.
 	 */
 	public function get_playlist() {
-		$response = $this->send_request( 'GET', '/playlist' );
+		$response = $this->send_request( 'GET', '/playlist', [], [], MINUTE_IN_SECONDS );
 
-		if ( is_wp_error( $response ) ) {
-			$this->handle_error( $response );
+		if ( is_wp_error( $response ) || ! isset( $response['series'] ) ) {
+			if ( is_wp_error( $response ) ) {
+				$this->handle_error( $response );
+			}
 
 			return [
 				'series' => [],
 			];
+		}
+
+		/**
+		 * Filter the topics that should be displayed in the playlist.
+		 *
+		 * @param array $excluded An array of topic slugs and/or legacy IDs that should be excluded
+		 *                        from display in the playlist.
+		 */
+		$excluded = apply_filters( 'wp101_excluded_topics', [] );
+
+		if ( ! empty( $excluded ) ) {
+			foreach ( $response['series'] as $key => $series ) {
+				$response['series'][ $key ]['topics'] = array_filter(
+					$series['topics'],
+					function ( $topic ) use ( $excluded ) {
+						return ! in_array( $topic['slug'], $excluded, true )
+							&& ! in_array( $topic['legacy_id'], $excluded, true );
+					}
+				);
+			}
 		}
 
 		return $response;

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -308,7 +308,14 @@ class ApiTest extends TestCase {
 	public function test_get_playlist() {
 		$json = [
 			'status' => 'success',
-			'data'   => [],
+			'data'   => [
+				'series' => [
+					'slug'   => 'some-slug',
+					'topics' => [
+						'slug' => 'video-' . uniqid(),
+					],
+				],
+			],
 		];
 
 		$this->set_expected_response( [
@@ -324,6 +331,173 @@ class ApiTest extends TestCase {
 		} );
 
 		$this->assertEquals( [ 'series' => [] ], API::get_instance()->get_playlist() );
+	}
+
+	public function test_get_playlist_handles_malformed_responses() {
+		$this->set_expected_response( [
+			'body' => wp_json_encode( [
+				'status' => 'success',
+				'data'   => [
+					'some irrelevant values.',
+				],
+			] ),
+		] );
+
+		$this->assertEquals( [ 'series' => [] ], API::get_instance()->get_playlist() );
+	}
+
+	/**
+	 * @ticket https://github.com/101videos/wp101plugin/issues/50
+	 */
+	public function test_get_playlist_can_filter_results_by_slug() {
+		$playlist = [
+			'series' => [
+				[
+					'slug'   => 'first-series',
+					'topics' => [
+						[
+							'slug'      => 'first-video',
+							'legacy_id' => 'plugin.1',
+						],
+						[
+							'slug'      => 'second-video',
+							'legacy_id' => 'plugin.2',
+						]
+					],
+				],
+			],
+		];
+
+		$this->set_expected_response( [
+			'body' => wp_json_encode( [
+				'status' => 'success',
+				'data'   => $playlist,
+			] ),
+		] );
+
+
+		add_filter( 'wp101_excluded_topics', function () {
+			return [
+				'first-video',
+			];
+		} );
+
+		$result = API::get_instance()->get_playlist();
+
+		$this->assertCount( 1, $result['series'][0]['topics'] );
+
+		$this->assertSame(
+			$playlist['series'][0]['topics'][1]['slug'],
+			current($result['series'][0]['topics'])['slug']
+		);
+	}
+
+	/**
+	 * @ticket https://github.com/101videos/wp101plugin/issues/50
+	 */
+	public function test_get_playlist_can_filter_results_across_multiple_series() {
+		$playlist = [
+			'series' => [
+				[
+					'slug'   => 'first-series',
+					'topics' => [
+						[
+							'slug'      => 'first-video',
+							'legacy_id' => 'plugin.1',
+						],
+						[
+							'slug'      => 'second-video',
+							'legacy_id' => 'plugin.2',
+						]
+					],
+				],
+				[
+					'slug'   => 'second-series',
+					'topics' => [
+						[
+							'slug'      => 'third-video',
+							'legacy_id' => 'plugin.3',
+						],
+						[
+							'slug'      => 'fourth-video',
+							'legacy_id' => 'plugin.4',
+						]
+					],
+				],
+			],
+		];
+
+		$this->set_expected_response( [
+			'body' => wp_json_encode( [
+				'status' => 'success',
+				'data'   => $playlist,
+			] ),
+		] );
+
+
+		add_filter( 'wp101_excluded_topics', function () {
+			return [
+				'first-video',
+				'fourth-video',
+			];
+		} );
+
+		$result = API::get_instance()->get_playlist();
+
+		$this->assertCount( 1, $result['series'][0]['topics'] );
+		$this->assertSame(
+			$playlist['series'][0]['topics'][1]['slug'],
+			current($result['series'][0]['topics'])['slug']
+		);
+		$this->assertCount( 1, $result['series'][1]['topics'] );
+		$this->assertSame(
+			$playlist['series'][1]['topics'][0]['slug'],
+			current($result['series'][1]['topics'])['slug']
+		);
+	}
+
+	/**
+	 * @ticket https://github.com/101videos/wp101plugin/issues/50
+	 */
+	public function test_get_playlist_can_filter_results_by_legacy_id() {
+		$playlist = [
+			'series' => [
+				[
+					'slug'   => 'first-series',
+					'topics' => [
+						[
+							'slug'      => 'first-video',
+							'legacy_id' => 'plugin.1',
+						],
+						[
+							'slug'      => 'second-video',
+							'legacy_id' => 'plugin.2',
+						]
+					],
+				]
+			],
+		];
+
+		$this->set_expected_response( [
+			'body' => wp_json_encode( [
+				'status' => 'success',
+				'data'   => $playlist,
+			] ),
+		] );
+
+		add_filter( 'wp101_excluded_topics', function () {
+			return [
+				'plugin.2',
+			];
+		} );
+
+		$result = API::get_instance()->get_playlist();
+
+		$this->assertCount( 1, $result['series'][0]['topics'] );
+		$this->assertSame(
+			$playlist['series'][0]['topics'][0]['slug'],
+			current($result['series'][0]['topics'])['slug']
+		);
 	}
 
 	public function test_get_series() {


### PR DESCRIPTION
Add a `wp101_excluded_topics` filter, which can be given either a slug (preferred) or a legacy ID to automatically hide those videos from appearing in the playlist.

```php
add_filter( 'wp101_excluded_topics', function ( $topics ) {
  $topics[] = 'some-video-slug';
  $topics[] = 'some-plugin.legacy_id';

  return $topics;
} );
```

Fixes #50.