### PR TITLE
WIP: Clear cache button

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -232,6 +232,15 @@ function render_listings_page() {
  * Render the WP101 settings page.
  */
 function render_settings_page() {
+	if ( isset( $_POST['_wpnonce'] ) && wp_verify_nonce( $_POST['_wpnonce'], 'wp101-flush-cache' ) ) {
+		/**
+		 * Flush caches related to the WP101 plugin.
+		 */
+		do_action( 'wp101_flush_cache' );
+
+		add_settings_error( 'wp101', 'flush_cache', __( 'The WP101 cache has been flushed.', 'wp101' ), 'updated' );
+	}
+
 	include WP101_VIEWS . '/settings.php';
 }
 

--- a/views/settings.php
+++ b/views/settings.php
@@ -31,55 +31,68 @@ $masked = str_pad(
 
 	<?php settings_errors(); ?>
 
-	<h2 id="api-key"><?php echo esc_html_x( 'WP101Plugin.com API Key', 'settings section heading', 'wp101' ); ?></h2>
-	<p><?php esc_html_e( 'Your API key enables your WordPress site to connect to WP101 and retrieve all of your videos.', 'wp101' ); ?></p>
-	<p><strong><?php esc_html_e( 'Don\'t have an API key?', 'wp101' ); ?></strong></p>
-	<p><a href="https://wp101plugin.com" class="button" target="_blank"><?php esc_html_e( 'Get your key now!', 'wp101' ); ?></a></p>
+	<section id="api-key">
+		<h2><?php echo esc_html_x( 'WP101Plugin.com API Key', 'settings section heading', 'wp101' ); ?></h2>
+		<p><?php esc_html_e( 'Your API key enables your WordPress site to connect to WP101 and retrieve all of your videos.', 'wp101' ); ?></p>
+		<p><strong><?php esc_html_e( 'Don\'t have an API key?', 'wp101' ); ?></strong></p>
+		<p><a href="https://wp101plugin.com" class="button" target="_blank"><?php esc_html_e( 'Get your key now!', 'wp101' ); ?></a></p>
 
-	<?php if ( defined( 'WP101_API_KEY' ) ) : ?>
+		<?php if ( defined( 'WP101_API_KEY' ) ) : ?>
 
-		<div id="wp101-api-key-set-via-constant-notice" class="notice notice-info">
-			<p><strong><?php esc_html_e( 'Your API key is defined in your wp-config.php file.', 'wp101' ); ?></strong></p>
-			<p><?php esc_html_e( 'To make changes, please open your wp-config.php file in a text editor and look for the line that includes:', 'wp101' ); ?></p>
-			<pre><code>define( 'WP101_API_KEY', '...' );</code></pre>
-		</div>
+			<div id="wp101-api-key-set-via-constant-notice" class="notice notice-info">
+				<p><strong><?php esc_html_e( 'Your API key is defined in your wp-config.php file.', 'wp101' ); ?></strong></p>
+				<p><?php esc_html_e( 'To make changes, please open your wp-config.php file in a text editor and look for the line that includes:', 'wp101' ); ?></p>
+				<pre><code>define( 'WP101_API_KEY', '...' );</code></pre>
+			</div>
 
-	<?php else : ?>
+		<?php else : ?>
 
-		<div id="wp101-settings-api-key-form" <?php echo ! empty( $api_key ) ? 'class="hide-if-js"' : ''; ?>>
-			<form method="post" action="options.php">
-				<?php settings_fields( 'wp101' ); ?>
+			<div id="wp101-settings-api-key-form" <?php echo ! empty( $api_key ) ? 'class="hide-if-js"' : ''; ?>>
+				<form method="post" action="options.php">
+					<?php settings_fields( 'wp101' ); ?>
 
+					<table class="form-table">
+						<th scope="row">
+							<label for="wp101-api-key"><?php esc_html_e( 'API key', 'wp101' ); ?></label>
+						</th>
+						<td>
+							<input name="wp101_api_key" id="wp101-api-key" type="text" class="regular-text code" />
+						</td>
+					</table>
+
+					<?php submit_button(); ?>
+				</form>
+			</div>
+
+		<?php endif; ?>
+
+		<?php if ( ! empty( $api_key ) ) : ?>
+
+			<div id="wp101-settings-api-key-display">
 				<table class="form-table">
 					<th scope="row">
 						<label for="wp101-api-key"><?php esc_html_e( 'API key', 'wp101' ); ?></label>
 					</th>
 					<td>
-						<input name="wp101_api_key" id="wp101-api-key" type="text" class="regular-text code" />
+						<code><?php echo esc_html( $masked ); ?></code>
+						<?php if ( ! defined( 'WP101_API_KEY' ) ) : ?>
+							<button id="wp101-settings-replace-api-key" class="button" style="vertical-align: baseline;"><?php esc_html_e( 'Replace my API Key', 'wp101' ); ?></button>
+						<?php endif; ?>
 					</td>
 				</table>
+			</div>
 
-				<?php submit_button(); ?>
-			</form>
-		</div>
+		<?php endif; ?>
+	</section>
 
-	<?php endif; ?>
+	<section id="tools">
+		<h2><?php echo esc_html_x( 'Troubleshooting', 'settings section heading', 'wp101' ); ?></h2>
 
-	<?php if ( ! empty( $api_key ) ) : ?>
+		<form method="POST">
+			<p><?php esc_html_e( 'If you\'re running into issues viewing WP101 content (or recently-purchased content is not appearing), you may need to flush the WP101 cache:', 'wp101' ); ?></p>
+			<input type="submit" value="<?php esc_attr_e( 'Flush WP101 Cache', 'wp101' ); ?>" class="button button-primary" />
+			<?php wp_nonce_field( 'wp101-flush-cache' ); ?>
+		</form>
 
-		<div id="wp101-settings-api-key-display">
-			<table class="form-table">
-				<th scope="row">
-					<label for="wp101-api-key"><?php esc_html_e( 'API key', 'wp101' ); ?></label>
-				</th>
-				<td>
-					<code><?php echo esc_html( $masked ); ?></code>
-					<?php if ( ! defined( 'WP101_API_KEY' ) ) : ?>
-						<button id="wp101-settings-replace-api-key" class="button" style="vertical-align: baseline;"><?php esc_html_e( 'Replace my API Key', 'wp101' ); ?></button>
-					<?php endif; ?>
-				</td>
-			</table>
-		</div>
-
-	<?php endif; ?>
+	</section>
 </div>


### PR DESCRIPTION
This pull request introduces a "Clear Cache" button on the WP101 settings screen, enabling users to flush WP101-related caches.

Fixes #51.