### PR TITLE
Add a new wp101_is_relevant_series filter

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -265,13 +265,21 @@ add_action( 'update_option_wp101_api_key', __NAMESPACE__ . '\clear_public_api_ke
  * @return bool Whether or not the series should be displayed.
  */
 function is_relevant_series( $series ) {
-	if ( ! isset( $series['restrictions']['plugins'] ) || empty( $series['restrictions']['plugins'] ) ) {
-		return true;
+	$is_relevant = true;
+
+	if ( ! empty( $series['restrictions']['plugins'] ) ) {
+		$restrictions = array_filter( $series['restrictions']['plugins'], 'is_plugin_active' );
+
+		$is_relevant = ! empty( $restrictions );
 	}
 
-	$restrictions = array_filter( $series['restrictions']['plugins'], 'is_plugin_active' );
-
-	return ! empty( $restrictions );
+	/**
+	 * Determine if a series is relevant for the given site.
+	 *
+	 * @param bool  $is_relevant Whether or not the series is relevant for this site.
+	 * @param array $series      The series details.
+	 */
+	return apply_filters( 'wp101_is_relevant_series', $is_relevant, $series );
 }
 
 /**

--- a/tests/test-admin.php
+++ b/tests/test-admin.php
@@ -267,6 +267,22 @@ class AdminTest extends TestCase {
 		$this->assertTrue( Admin\is_relevant_series( $series ) );
 	}
 
+	public function test_is_relevant_series_can_be_overridden_via_filter() {
+		$series = [
+			'restrictions' => [
+				'plugins' => [
+					'some-plugin/some-plugin.php',
+				],
+			],
+		];
+
+		update_option( 'active_plugins', [] );
+
+		add_filter( 'wp101_is_relevant_series', '__return_true' );
+
+		$this->assertTrue( Admin\is_relevant_series( $series ) );
+	}
+
 	/**
 	 * @link https://github.com/liquidweb/wp101plugin/issues/40
 	 */


### PR DESCRIPTION
The WP101 plugin automatically attempts to filter out series that are not relevant for a given site (e.g. if a site isn't running Jetpack, there's no reason to show the Jetpack videos). However, sometimes it's desired to override this behavior, so the new `wp101_is_relevant_series` filter is here to accomplish that.

## Usage

```php
// Include the series with slug "some-series".
add_filter( 'wp101_is_relevant_series', function ( $is_relevant, $series ) {
    return 'some-series' === $series['slug'] ? true : $is_relevant;
} );
```