### PR TITLE
Send the Origin, not X-Forwarded-Host, HTTP header with API requests

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -458,9 +458,9 @@ class API {
 				'timeout'    => 30,
 				'user-agent' => self::USER_AGENT,
 				'headers'    => [
-					'Authorization'    => 'Bearer ' . $api_key,
-					'Method'           => $method,
-					'X-Forwarded-Host' => site_url(),
+					'Authorization' => 'Bearer ' . $api_key,
+					'Method'        => $method,
+					'Origin'        => site_url(),
 				],
 			]
 		);

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -888,7 +888,7 @@ class ApiTest extends TestCase {
 			$this->assertEquals( 'GET', $args['method'] );
 			$this->assertContains( '/test-endpoint', $url );
 			$this->assertEquals( 'Bearer ' . $key, $args['headers']['Authorization'] );
-			$this->assertEquals( site_url(), $args['headers']['X-Forwarded-Host'] );
+			$this->assertEquals( site_url(), $args['headers']['Origin'] );
 			$this->assertEquals( API::USER_AGENT, $args['user-agent']);
 
 			return $response;


### PR DESCRIPTION
Within the WP101 Plugin app, we need to know what domain the plugin is running on so that we may ensure the correct videos are getting served.

For the longest time, we've been using `X-Forwarded-Host`, but this header will get overwritten on systems leveraging any sort of load balancer or other proxy. The **proper** header in this case is `Origin`. [From MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin):

> The `Origin` request header indicates the origin (scheme, hostname, and port) that caused the request. For example, if a user agent needs to request resources included in a page, or fetched by scripts that it executes, then the origin of the page may be included in the request.