### PR TITLE
Make wp101:__wakeup() public

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -68,7 +68,7 @@ class API {
 	/**
 	 * Prevent the object from being deserialized.
 	 */
-	private function __wakeup() {}
+	public function __wakeup() {}
 
 	/**
 	 * Retrieve the singular instance of the class.


### PR DESCRIPTION
PHP8 requires that the magic methods be public, which means on systems with PHP8 this method can throw the error
> The magic method WP101\API::__wakeup() must have public visibility

This PR fixes that error by making the method public. 